### PR TITLE
chore: upstream rebase kilt changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo build --release
 ./target/release/telemetry --help
 ```
 
-By default, telemetry will listen on the local interface only (127.0.0.1) on port 8000. You may change both those values with the `--listen` flag as shown below:
+By default, telemetry will listen on the local interface only (127.0.0.1) on port 8080. You may change both those values with the `--listen` flag as shown below:
 
 ```
 telemetry --listen 0.0.0.0:8888
@@ -49,7 +49,7 @@ yarn start
 Follow up installation instructions from the [Polkadot repo](https://github.com/paritytech/polkadot)
 
 ```sh
-polkadot --dev --telemetry-url ws://localhost:8000/submit
+polkadot --dev --telemetry-url ws://localhost:8080/submit
 ```
 
 ## Docker
@@ -62,21 +62,21 @@ For the sake of brevity below, I will name the containers `backend` and `fronten
 Let's start the backend first. We will be using the published [chevdor](https://hub.docker.com/u/chevdor) images here, feel free to replace with your own image.
 
 ```
-docker run --rm -i --name backend -p 8000:8000 \
-  chevdor/substrate-telemetry-backend -l 0.0.0.0:8000
+docker run --rm -i --name backend -p 8080:8080 \
+  chevdor/substrate-telemetry-backend -l 0.0.0.0:8080
 ```
 
 Let's now start the frontend:
 
 ```
 docker run --rm -i --name frontend --link backend -p 80:80 \
-  -e SUBSTRATE_TELEMETRY_URL=ws://localhost:8000/feed \
+  -e REACT_APP_WS_URL=ws://localhost:8080/feed \
   chevdor/substrate-telemetry-frontend
 ```
 
 WARNING: Do not forget the `/feed` part of the URL...
 
-NOTE: Here we used `SUBSTRATE_TELEMETRY_URL=ws://localhost:8000/feed`. This will work if you test with everything running locally on your machine but NOT if your backend runs on a remote server. Keep in mind that the frontend docker image is serving a static site running your browser. The `SUBSTRATE_TELEMETRY_URL` is the WebSocket url that your browser will use to reach the backend. Say your backend runs on a remore server at `192.168.0.100`, you will need to set the IP/url accordingly in `SUBSTRATE_TELEMETRY_URL`.
+NOTE: Here we used `REACT_APP_WS_URL=ws://localhost:8080/feed`. This will work if you test with everything running locally on your machine but NOT if your backend runs on a remote server. Keep in mind that the frontend docker image is serving a static site running your browser. The `REACT_APP_WS_URL` is the WebSocket url that your browser will use to reach the backend. Say your backend runs on a remore server at `192.168.0.100`, you will need to set the IP/url accordingly in `REACT_APP_WS_URL`.
 
 At that point, you can already open your browser at [http://localhost](http://localhost/) and see that telemetry is waiting for data.
 
@@ -84,7 +84,7 @@ Let's bring some data in with  a node:
 
 ```
 docker run --rm -i --name substrate --link backend -p 9944:9944 \
-  chevdor/substrate substrate --dev --telemetry-url 'ws://backend:8000/submit 0'
+  chevdor/substrate substrate --dev --telemetry-url 'ws://backend:8080/submit 0'
 ```
 
 You should now see your node showing up in your local [telemetry frontend](http://localhost/):
@@ -111,4 +111,12 @@ The building process is standard. You just need to notice that the Dockerfile is
 
 ```
 DOCKER_USER=chevdor ./scripts/build-docker-frontend.sh
+```
+
+### Configuration
+
+When backend and frontend are running in different environments, you can inject the web socket endpoint url into the frontend by exporting the environment variable REACT_APP_WS_URL:
+
+```
+export REACT_APP_WS_URL=ws://my-host:8080/feed && yarn start:frontend
 ```

--- a/backend.Dockerfile
+++ b/backend.Dockerfile
@@ -9,6 +9,6 @@ FROM phusion/baseimage:0.11
 
 COPY --from=builder /build/target/release/telemetry /usr/local/bin
 
-EXPOSE 8000
+EXPOSE 8080
 
 ENTRYPOINT [ "telemetry" ]

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "telemetry"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "actix-http 0.2.10 (git+https://github.com/maciejhirsz/actix-web)",

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,6 @@ WORKDIR /usr/local/bin
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/$PROFILE/telemetry /usr/local/bin
 
-EXPOSE 8000
+EXPOSE 8080
 
 ENTRYPOINT ["telemetry"]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -33,8 +33,8 @@ struct Opts {
     #[clap(
         short = "l",
         long = "listen",
-        default_value = "127.0.0.1:8000",
-        help = "This is the socket address Telemetry is listening to. This is restricted localhost (127.0.0.1) by default and should be fine for most use cases. If you are using Telemetry in a container, you likely want to set this to '0.0.0.0:8000'"
+        default_value = "127.0.0.1:8080",
+        help = "This is the socket address Telemetry is listening to. This is restricted localhost (127.0.0.1) by default and should be fine for most use cases. If you are using Telemetry in a container, you likely want to set this to '0.0.0.0:8080'"
     )]
     socket: std::net::SocketAddr,
 }
@@ -106,7 +106,7 @@ fn health(
     })
 }
 
-/// Telemetry entry point. Listening by default on 127.0.0.1:8000.
+/// Telemetry entry point. Listening by default on 127.0.0.1:8080.
 /// This can be changed using the `PORT` and `BIND` ENV variables.
 fn main() -> std::io::Result<()> {
     use web::{get, resource};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,6 @@ services:
       dockerfile: backend.Dockerfile
       context: ./
     environment:
-      - PORT=8000
+      - PORT=8080
     ports:
-      - 8000:8000
+      - 8080:8080

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -16,7 +16,7 @@ FROM nginx:stable-alpine
 LABEL maintainer="Chevdor <chevdor@gmail.com>"
 LABEL description="Polkadot Telemetry frontend"
 
-ENV SUBSTRATE_TELEMETRY_URL=
+ENV REACT_APP_WS_URL=
 
 WORKDIR /usr/share/nginx/html
 

--- a/frontend/env.sh
+++ b/frontend/env.sh
@@ -9,7 +9,7 @@ TARGET=./env-config.js
 echo -n > $TARGET
 
 declare -a vars=(
-  "SUBSTRATE_TELEMETRY_URL"
+  "REACT_APP_WS_URL"
   "SUBSTRATE_TELEMETRY_SAMPLE"
 )
 

--- a/frontend/src/Connection.ts
+++ b/frontend/src/Connection.ts
@@ -35,7 +35,7 @@ export class Connection {
   private static readonly address = Connection.getAddress();
 
   private static getAddress(): string {
-    const ENV_URL = 'SUBSTRATE_TELEMETRY_URL';
+    const ENV_URL = 'REACT_APP_WS_URL';
 
     if (process.env && process.env[ENV_URL]) {
       return process.env[ENV_URL] as string;
@@ -49,7 +49,7 @@ export class Connection {
       return `wss://${window.location.hostname}/feed/`;
     }
 
-    return `ws://127.0.0.1:8000/feed`;
+    return `ws://127.0.0.1:8080/feed`;
   }
 
   private static async socket(): Promise<WebSocket> {

--- a/frontend/src/components/List/Column.tsx
+++ b/frontend/src/components/List/Column.tsx
@@ -480,7 +480,7 @@ const MEMORY_SCALE = 2 * 1024 * 1024;
 const URI_BASE =
   window.location.protocol === 'https:'
     ? `/network_state/`
-    : `http://${window.location.hostname}:8000/network_state/`;
+    : `http://${window.location.hostname}:8080/network_state/`;
 
 function formatStamp(stamp: Types.Timestamp): string {
   const passed = ((timestamp() - stamp) / 1000) | 0;


### PR DESCRIPTION
## fixes KILTProtocol/ticket#539

Rebased to upstream, fixed minor CRA oversight by parity. Moved default port from 8000 to 8080.

## How to test:

 - build and run with README

 - start node with `--telemetry-url ws://127.0.0.1:8080/submit` parameter


## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [x] I have [left the code in a better state](https://deviq.com/boy-scout-rule/)
- [x] I have documented the changes (where applicable)
